### PR TITLE
use alt as download filename

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -54,29 +54,29 @@
 <article id="app" class="page">
   <h1>Vue &lt;<strong>PictureSharesheet</strong>/&gt;</h1>
   <p>A Vue Picture Sharesheet Component heavily inspired<br> by the Image Sharesheet in Apple's Newsroom</p>
-  <picture-sharesheet class="test" src="https://source.unsplash.com/800x600/?cat" alt="Was alt?" sharemessage="YAY"></picture-sharesheet>
+  <picture-sharesheet class="test" src="https://source.unsplash.com/800x600/?cat" alt="This is alt" sharemessage="YAY"></picture-sharesheet>
   <h2>Position</h2>
   <div class="pos-grid">
     <div>
       <p>position="top"</p>
-      <picture-sharesheet src="https://source.unsplash.com/600x500/?cat" position="top"></picture-sharesheet>
+      <picture-sharesheet src="https://source.unsplash.com/600x500/?cat" alt="This is alt" position="top"></picture-sharesheet>
     </div>
     <div>
       <p>position="left"</p>
-      <picture-sharesheet src="https://source.unsplash.com/600x550/?cat" position="left"></picture-sharesheet>
+      <picture-sharesheet src="https://source.unsplash.com/600x550/?cat" alt="This is alt" position="left"></picture-sharesheet>
     </div>
     <div>
       <p>position="bottom"</p>
-      <picture-sharesheet src="https://source.unsplash.com/600x600/?cat" position="bottom"></picture-sharesheet>
+      <picture-sharesheet src="https://source.unsplash.com/600x600/?cat" alt="This is alt" position="bottom"></picture-sharesheet>
     </div>
     <div>
       <p>position="right"</p>
-      <picture-sharesheet src="https://source.unsplash.com/600x650/?cat" position="right"></picture-sharesheet>
+      <picture-sharesheet src="https://source.unsplash.com/600x650/?cat" alt="This is alt" position="right"></picture-sharesheet>
     </div>
   </div>
 
   <h2>Color & Fixed</h2>
-  <picture-sharesheet src="https://source.unsplash.com/800x500/?cat" sheetcolor="#FFF" iconcolor="#000" fixed></picture-sharesheet>
+  <picture-sharesheet src="https://source.unsplash.com/800x500/?cat" alt="This is alt" sheetcolor="#FFF" iconcolor="#000" fixed></picture-sharesheet>
   <p> &lt;picture-sharesheet src="..." sheetcolor="#FFF" iconcolor="#000" fixed &gt;</p>
 
 

--- a/src/PictureSharesheet.vue
+++ b/src/PictureSharesheet.vue
@@ -90,11 +90,12 @@
       },
       download() {
         let link = document.createElement('a');
+        let filename = this.alt || 'download';
         this.toDataURL(
           this.src,
           function(dataUrl) {
             link.setAttribute('href', dataUrl);
-            link.setAttribute('download', 'download.jpg');
+            link.setAttribute('download', `${filename}.jpg`);
             link.setAttribute('target', '_blank');
             link.style.display = 'none';
             document.body.appendChild(link);


### PR DESCRIPTION
I think use alt as download filename is the better way to distinguish local image file than use `download.jpg` ; ) 